### PR TITLE
xxh3: fix non-amd64 build

### DIFF
--- a/vector_hash_other.go
+++ b/vector_hash_other.go
@@ -7,4 +7,4 @@ const (
 	sse2 = false
 )
 
-func hash_vector(s string) u64 { return 0 }
+func hash_vector(_ ptr, _ u64) u64 { return 0 }


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

Fixes:

```
$ GOARCH=mips64 go build
# github.com/zeebo/xxh3
./hash.go:236:21: too many arguments in call to hash_vector
        have (unsafe.Pointer, uint64)
        want (string)
```