### PR TITLE
bugfix hashLarge128 returning type is invalid on arm

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -9,8 +9,7 @@ import (
 // Uint128 is a 128 bit value.
 // The actual value can be thought of as u.Hi<<64 | u.Lo.
 type Uint128 struct {
-	Hi uint64
-	Lo uint64
+	Hi, Lo uint64
 }
 
 type (

--- a/vector_hash_other.go
+++ b/vector_hash_other.go
@@ -1,3 +1,4 @@
+//go:build !amd64
 // +build !amd64
 
 package xxh3
@@ -20,9 +21,9 @@ func hashLarge(p ptr, l u64) (acc u64) {
 	return xxh3Avalanche(acc)
 }
 
-func hashLarge128(p ptr, l u64) (acc [2]u64) {
-	acc[1] = l * prime64_1
-	acc[0] = ^(l * prime64_2)
+func hashLarge128(p ptr, l u64) (acc u128) {
+	acc.Lo = l * prime64_1
+	acc.Hi = ^(l * prime64_2)
 
 	accs := [8]u64{
 		prime32_3, prime64_1, prime64_2, prime64_3,
@@ -31,17 +32,17 @@ func hashLarge128(p ptr, l u64) (acc [2]u64) {
 	accumScalar(&accs, p, key, l)
 
 	// merge accs
-	acc[1] += mulFold64(accs[0]^key64_011, accs[1]^key64_019)
-	acc[1] += mulFold64(accs[2]^key64_027, accs[3]^key64_035)
-	acc[1] += mulFold64(accs[4]^key64_043, accs[5]^key64_051)
-	acc[1] += mulFold64(accs[6]^key64_059, accs[7]^key64_067)
-	acc[1] = xxh3Avalanche(acc[1])
+	acc.Lo += mulFold64(accs[0]^key64_011, accs[1]^key64_019)
+	acc.Lo += mulFold64(accs[2]^key64_027, accs[3]^key64_035)
+	acc.Lo += mulFold64(accs[4]^key64_043, accs[5]^key64_051)
+	acc.Lo += mulFold64(accs[6]^key64_059, accs[7]^key64_067)
+	acc.Lo = xxh3Avalanche(acc.Lo)
 
-	acc[0] += mulFold64(accs[0]^key64_117, accs[1]^key64_125)
-	acc[0] += mulFold64(accs[2]^key64_133, accs[3]^key64_141)
-	acc[0] += mulFold64(accs[4]^key64_149, accs[5]^key64_157)
-	acc[0] += mulFold64(accs[6]^key64_165, accs[7]^key64_173)
-	acc[0] = xxh3Avalanche(acc[0])
+	acc.Hi += mulFold64(accs[0]^key64_117, accs[1]^key64_125)
+	acc.Hi += mulFold64(accs[2]^key64_133, accs[3]^key64_141)
+	acc.Hi += mulFold64(accs[4]^key64_149, accs[5]^key64_157)
+	acc.Hi += mulFold64(accs[6]^key64_165, accs[7]^key64_173)
+	acc.Hi = xxh3Avalanche(acc.Hi)
 
 	return acc
 }


### PR DESCRIPTION
Hi, Thank you for providing a great library.

This PR resolves https://github.com/zeebo/xxh3/issues/8
The return type of hashLarge128 was not modified as amd64, so I modified it in this PR.

I have tested it on M1 macos (Apple Silicon) & Thinkpad X1 Carbon w/ ArchLinux(Intel CPU)