### PR TITLE
Use correct sized constant

### DIFF
--- a/accum_vector_avx_amd64.s
+++ b/accum_vector_avx_amd64.s
@@ -2,11 +2,11 @@
 
 #include "textflag.h"
 
-DATA prime_avx<>+0(SB)/4, $0x9e3779b1
-DATA prime_avx<>+8(SB)/4, $0x9e3779b1
-DATA prime_avx<>+16(SB)/4, $0x9e3779b1
-DATA prime_avx<>+24(SB)/4, $0x9e3779b1
-GLOBL prime_avx<>(SB), RODATA|NOPTR, $28
+DATA prime_avx<>+0(SB)/8, $0x000000009e3779b1
+DATA prime_avx<>+8(SB)/8, $0x000000009e3779b1
+DATA prime_avx<>+16(SB)/8, $0x000000009e3779b1
+DATA prime_avx<>+24(SB)/8, $0x000000009e3779b1
+GLOBL prime_avx<>(SB), RODATA|NOPTR, $32
 
 // func accumAVX2(acc *[8]uint64, data *byte, key *byte, len uint64)
 // Requires: AVX, AVX2, MMX+

--- a/avo/avx.go
+++ b/avo/avx.go
@@ -10,7 +10,7 @@ func AVX() {
 	// Lay out the prime constant in memory, copy it so no unpack is needed.
 	primeData := GLOBL("prime_avx", RODATA|NOPTR)
 	for i := 0; i < 32; i += 8 {
-		DATA(i, U32(2654435761))
+		DATA(i, U64(2654435761))
 	}
 
 	{


### PR DESCRIPTION
This worked because of alignment. Instead use explicit uint64s.