### PR TITLE
Fix non-amd64 builds

### DIFF
--- a/accum_stubs_other.go
+++ b/accum_stubs_other.go
@@ -13,10 +13,11 @@ const (
 	hasAVX512 = false
 )
 
-func accumAVX2(acc *[8]u64, data, key unsafe.Pointer, len u64) { panic("unreachable") }
-func accumSSE(acc *[8]u64, data, key unsafe.Pointer, len u64)  { panic("unreachable") }
-func accumBlockAVX2(acc *[8]u64, data, key unsafe.Pointer)     { panic("unreachable") }
-func accumBlockSSE(acc *[8]u64, data, key unsafe.Pointer)      { panic("unreachable") }
+func accumAVX2(acc *[8]u64, data, key unsafe.Pointer, len u64)   { panic("unreachable") }
+func accumSSE(acc *[8]u64, data, key unsafe.Pointer, len u64)    { panic("unreachable") }
+func accumBlockAVX2(acc *[8]u64, data, key unsafe.Pointer)       { panic("unreachable") }
+func accumBlockSSE(acc *[8]u64, data, key unsafe.Pointer)        { panic("unreachable") }
+func accumAVX512(acc *[8]u64, data, key unsafe.Pointer, len u64) { panic("unreachable") }
 
 func withAVX2(cb func())    { cb() }
 func withSSE2(cb func())    { cb() }


### PR DESCRIPTION
Add missing stub.

Fixes #15

Release v1.0.0 proper? `go get github.com/zeebo/xxh3@latest` still fetches the broken one.