### PR TITLE
fix: mark Hash arg as noescape

### DIFF
--- a/hash64.go
+++ b/hash64.go
@@ -8,8 +8,7 @@ func Hash(b []byte) uint64 {
 	if len(b) <= 16 {
 		fn = hashSmall
 	}
-	return fn(*(*str)(ptr(&b)))
-
+	return fn(*(*str)(noescape(ptr(&b))))
 }
 
 // Hash returns the hash of the string slice.

--- a/hash64_test.go
+++ b/hash64_test.go
@@ -1,6 +1,7 @@
 package xxh3
 
 import (
+	"encoding/binary"
 	"fmt"
 	"runtime"
 	"testing"
@@ -27,7 +28,6 @@ func BenchmarkFixed64(b *testing.B) {
 				}
 				runtime.KeepAlive(acc)
 			})
-
 		}
 
 		if i > 240 {
@@ -71,4 +71,12 @@ func BenchmarkFixed64(b *testing.B) {
 	r(1000 * 1024)
 	r(10000 * 1024)
 	r(100000 * 1024)
+}
+
+func BenchmarkHashEscape(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var b [8]byte
+		binary.LittleEndian.PutUint64(b[:], uint64(i))
+		_ = Hash(b[:])
+	}
 }

--- a/hash64_test.go
+++ b/hash64_test.go
@@ -74,6 +74,7 @@ func BenchmarkFixed64(b *testing.B) {
 }
 
 func BenchmarkHashEscape(b *testing.B) {
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		var b [8]byte
 		binary.LittleEndian.PutUint64(b[:], uint64(i))

--- a/utils.go
+++ b/utils.go
@@ -102,3 +102,15 @@ func mulFold64(x, y u64) u64 {
 	hi, lo := bits.Mul64(x, y)
 	return hi ^ lo
 }
+
+// noescape hides a pointer from escape analysis.  noescape is
+// the identity function but escape analysis doesn't think the
+// output depends on the input. noescape is inlined and currently
+// compiles down to zero instructions.
+// USE CAREFULLY!
+// This was copied from the runtime; see issues 23382 and 7921.
+//go:nosplit
+func noescape(p unsafe.Pointer) unsafe.Pointer {
+	x := uintptr(p)
+	return unsafe.Pointer(x ^ 0)
+}


### PR DESCRIPTION
Go code that uses `unsafe.Pointer` requires this hack or `[]byte` arg always escapes to heap. [cespare/xxhash](https://github.com/cespare/xxhash/blob/v2.1.2/xxhash_amd64.go#L10) uses asm with `go:noescape` instead. 

See https://github.com/golang/go/issues/23382 for an example from stdlib

```
benchmark                  old ns/op     new ns/op     delta
BenchmarkHashEscape-12     27.1          4.61          -83.03%

benchmark                  old allocs     new allocs     delta
BenchmarkHashEscape-12     1              0              -100.00%

benchmark                  old bytes     new bytes     delta
BenchmarkHashEscape-12     8             0             -100.00%
```