### PR TITLE
Improve pure Go speed up to 45%

### DIFF
--- a/accum_generic.go
+++ b/accum_generic.go
@@ -14,45 +14,66 @@ func accumScalar(accs *[8]u64, p, secret ptr, l u64) {
 
 		// accs
 		for i := 0; i < 16; i++ {
-			dv0 := readU64(p, 8*0)
-			dk0 := dv0 ^ readU64(k, 8*0)
-			accs[1] += dv0
-			accs[0] += (dk0 & 0xffffffff) * (dk0 >> 32)
+			{
+				const off = 0
+				dv0 := readU64(p, 8*off)
+				dk0 := dv0 ^ readU64(k, 8*off)
+				ac1 := dv0
+				ac0 := uint64(uint32(dk0)) * (dk0 >> 32)
 
-			dv1 := readU64(p, 8*1)
-			dk1 := dv1 ^ readU64(k, 8*1)
-			accs[0] += dv1
-			accs[1] += (dk1 & 0xffffffff) * (dk1 >> 32)
+				dv1 := readU64(p, 8*off+8)
+				dk1 := dv1 ^ readU64(k, 8*off+8)
+				ac0 += dv1
+				ac1 += uint64(uint32(dk1)) * (dk1 >> 32)
 
-			dv2 := readU64(p, 8*2)
-			dk2 := dv2 ^ readU64(k, 8*2)
-			accs[3] += dv2
-			accs[2] += (dk2 & 0xffffffff) * (dk2 >> 32)
+				accs[off] += ac0
+				accs[off+1] += ac1
+			}
+			{
+				const off = 2
+				dv0 := readU64(p, 8*off)
+				dk0 := dv0 ^ readU64(k, 8*off)
+				ac1 := dv0
+				ac0 := uint64(uint32(dk0)) * (dk0 >> 32)
 
-			dv3 := readU64(p, 8*3)
-			dk3 := dv3 ^ readU64(k, 8*3)
-			accs[2] += dv3
-			accs[3] += (dk3 & 0xffffffff) * (dk3 >> 32)
+				dv1 := readU64(p, 8*off+8)
+				dk1 := dv1 ^ readU64(k, 8*off+8)
+				ac0 += dv1
+				ac1 += uint64(uint32(dk1)) * (dk1 >> 32)
 
-			dv4 := readU64(p, 8*4)
-			dk4 := dv4 ^ readU64(k, 8*4)
-			accs[5] += dv4
-			accs[4] += (dk4 & 0xffffffff) * (dk4 >> 32)
+				accs[off] += ac0
+				accs[off+1] += ac1
+			}
+			{
+				const off = 4
+				dv0 := readU64(p, 8*off)
+				dk0 := dv0 ^ readU64(k, 8*off)
+				ac1 := dv0
+				ac0 := uint64(uint32(dk0)) * (dk0 >> 32)
 
-			dv5 := readU64(p, 8*5)
-			dk5 := dv5 ^ readU64(k, 8*5)
-			accs[4] += dv5
-			accs[5] += (dk5 & 0xffffffff) * (dk5 >> 32)
+				dv1 := readU64(p, 8*off+8)
+				dk1 := dv1 ^ readU64(k, 8*off+8)
+				ac0 += dv1
+				ac1 += uint64(uint32(dk1)) * (dk1 >> 32)
 
-			dv6 := readU64(p, 8*6)
-			dk6 := dv6 ^ readU64(k, 8*6)
-			accs[7] += dv6
-			accs[6] += (dk6 & 0xffffffff) * (dk6 >> 32)
+				accs[off] += ac0
+				accs[off+1] += ac1
+			}
+			{
+				const off = 6
+				dv0 := readU64(p, 8*off)
+				dk0 := dv0 ^ readU64(k, 8*off)
+				ac1 := dv0
+				ac0 := uint64(uint32(dk0)) * (dk0 >> 32)
 
-			dv7 := readU64(p, 8*7)
-			dk7 := dv7 ^ readU64(k, 8*7)
-			accs[6] += dv7
-			accs[7] += (dk7 & 0xffffffff) * (dk7 >> 32)
+				dv1 := readU64(p, 8*off+8)
+				dk1 := dv1 ^ readU64(k, 8*off+8)
+				ac0 += dv1
+				ac1 += uint64(uint32(dk1)) * (dk1 >> 32)
+
+				accs[off] += ac0
+				accs[off+1] += ac1
+			}
 
 			l -= _stripe
 			if l > 0 {
@@ -98,45 +119,66 @@ func accumScalar(accs *[8]u64, p, secret ptr, l u64) {
 		t, k := (l-1)/_stripe, secret
 
 		for i := u64(0); i < t; i++ {
-			dv0 := readU64(p, 8*0)
-			dk0 := dv0 ^ readU64(k, 8*0)
-			accs[1] += dv0
-			accs[0] += (dk0 & 0xffffffff) * (dk0 >> 32)
+			{
+				const off = 0
+				dv0 := readU64(p, 8*off)
+				dk0 := dv0 ^ readU64(k, 8*off)
+				ac1 := dv0
+				ac0 := uint64(uint32(dk0)) * (dk0 >> 32)
 
-			dv1 := readU64(p, 8*1)
-			dk1 := dv1 ^ readU64(k, 8*1)
-			accs[0] += dv1
-			accs[1] += (dk1 & 0xffffffff) * (dk1 >> 32)
+				dv1 := readU64(p, 8*off+8)
+				dk1 := dv1 ^ readU64(k, 8*off+8)
+				ac0 += dv1
+				ac1 += uint64(uint32(dk1)) * (dk1 >> 32)
 
-			dv2 := readU64(p, 8*2)
-			dk2 := dv2 ^ readU64(k, 8*2)
-			accs[3] += dv2
-			accs[2] += (dk2 & 0xffffffff) * (dk2 >> 32)
+				accs[off] += ac0
+				accs[off+1] += ac1
+			}
+			{
+				const off = 2
+				dv0 := readU64(p, 8*off)
+				dk0 := dv0 ^ readU64(k, 8*off)
+				ac1 := dv0
+				ac0 := uint64(uint32(dk0)) * (dk0 >> 32)
 
-			dv3 := readU64(p, 8*3)
-			dk3 := dv3 ^ readU64(k, 8*3)
-			accs[2] += dv3
-			accs[3] += (dk3 & 0xffffffff) * (dk3 >> 32)
+				dv1 := readU64(p, 8*off+8)
+				dk1 := dv1 ^ readU64(k, 8*off+8)
+				ac0 += dv1
+				ac1 += uint64(uint32(dk1)) * (dk1 >> 32)
 
-			dv4 := readU64(p, 8*4)
-			dk4 := dv4 ^ readU64(k, 8*4)
-			accs[5] += dv4
-			accs[4] += (dk4 & 0xffffffff) * (dk4 >> 32)
+				accs[off] += ac0
+				accs[off+1] += ac1
+			}
+			{
+				const off = 4
+				dv0 := readU64(p, 8*off)
+				dk0 := dv0 ^ readU64(k, 8*off)
+				ac1 := dv0
+				ac0 := uint64(uint32(dk0)) * (dk0 >> 32)
 
-			dv5 := readU64(p, 8*5)
-			dk5 := dv5 ^ readU64(k, 8*5)
-			accs[4] += dv5
-			accs[5] += (dk5 & 0xffffffff) * (dk5 >> 32)
+				dv1 := readU64(p, 8*off+8)
+				dk1 := dv1 ^ readU64(k, 8*off+8)
+				ac0 += dv1
+				ac1 += uint64(uint32(dk1)) * (dk1 >> 32)
 
-			dv6 := readU64(p, 8*6)
-			dk6 := dv6 ^ readU64(k, 8*6)
-			accs[7] += dv6
-			accs[6] += (dk6 & 0xffffffff) * (dk6 >> 32)
+				accs[off] += ac0
+				accs[off+1] += ac1
+			}
+			{
+				const off = 6
+				dv0 := readU64(p, 8*off)
+				dk0 := dv0 ^ readU64(k, 8*off)
+				ac1 := dv0
+				ac0 := uint64(uint32(dk0)) * (dk0 >> 32)
 
-			dv7 := readU64(p, 8*7)
-			dk7 := dv7 ^ readU64(k, 8*7)
-			accs[6] += dv7
-			accs[7] += (dk7 & 0xffffffff) * (dk7 >> 32)
+				dv1 := readU64(p, 8*off+8)
+				dk1 := dv1 ^ readU64(k, 8*off+8)
+				ac0 += dv1
+				ac1 += uint64(uint32(dk1)) * (dk1 >> 32)
+
+				accs[off] += ac0
+				accs[off+1] += ac1
+			}
 
 			l -= _stripe
 			if l > 0 {
@@ -150,42 +192,42 @@ func accumScalar(accs *[8]u64, p, secret ptr, l u64) {
 			dv0 := readU64(p, 8*0)
 			dk0 := dv0 ^ key64_121
 			accs[1] += dv0
-			accs[0] += (dk0 & 0xffffffff) * (dk0 >> 32)
+			accs[0] += uint64(uint32(dk0)) * (dk0 >> 32)
 
 			dv1 := readU64(p, 8*1)
 			dk1 := dv1 ^ key64_129
 			accs[0] += dv1
-			accs[1] += (dk1 & 0xffffffff) * (dk1 >> 32)
+			accs[1] += uint64(uint32(dk1)) * (dk1 >> 32)
 
 			dv2 := readU64(p, 8*2)
 			dk2 := dv2 ^ key64_137
 			accs[3] += dv2
-			accs[2] += (dk2 & 0xffffffff) * (dk2 >> 32)
+			accs[2] += uint64(uint32(dk2)) * (dk2 >> 32)
 
 			dv3 := readU64(p, 8*3)
 			dk3 := dv3 ^ key64_145
 			accs[2] += dv3
-			accs[3] += (dk3 & 0xffffffff) * (dk3 >> 32)
+			accs[3] += uint64(uint32(dk3)) * (dk3 >> 32)
 
 			dv4 := readU64(p, 8*4)
 			dk4 := dv4 ^ key64_153
 			accs[5] += dv4
-			accs[4] += (dk4 & 0xffffffff) * (dk4 >> 32)
+			accs[4] += uint64(uint32(dk4)) * (dk4 >> 32)
 
 			dv5 := readU64(p, 8*5)
 			dk5 := dv5 ^ key64_161
 			accs[4] += dv5
-			accs[5] += (dk5 & 0xffffffff) * (dk5 >> 32)
+			accs[5] += uint64(uint32(dk5)) * (dk5 >> 32)
 
 			dv6 := readU64(p, 8*6)
 			dk6 := dv6 ^ key64_169
 			accs[7] += dv6
-			accs[6] += (dk6 & 0xffffffff) * (dk6 >> 32)
+			accs[6] += uint64(uint32(dk6)) * (dk6 >> 32)
 
 			dv7 := readU64(p, 8*7)
 			dk7 := dv7 ^ key64_177
 			accs[6] += dv7
-			accs[7] += (dk7 & 0xffffffff) * (dk7 >> 32)
+			accs[7] += uint64(uint32(dk7)) * (dk7 >> 32)
 		}
 	}
 }
@@ -197,45 +239,66 @@ func accumBlockScalar(accs *[8]u64, p, secret ptr) {
 	}
 	// accs
 	for i := 0; i < 16; i++ {
-		dv0 := readU64(p, 8*0)
-		dk0 := dv0 ^ readU64(secret, 8*0)
-		accs[1] += dv0
-		accs[0] += (dk0 & 0xffffffff) * (dk0 >> 32)
+		{
+			const off = 0
+			dv0 := readU64(p, 8*off)
+			dk0 := dv0 ^ readU64(secret, 8*off)
+			ac1 := dv0
+			ac0 := uint64(uint32(dk0)) * (dk0 >> 32)
 
-		dv1 := readU64(p, 8*1)
-		dk1 := dv1 ^ readU64(secret, 8*1)
-		accs[0] += dv1
-		accs[1] += (dk1 & 0xffffffff) * (dk1 >> 32)
+			dv1 := readU64(p, 8*off+8)
+			dk1 := dv1 ^ readU64(secret, 8*off+8)
+			ac0 += dv1
+			ac1 += uint64(uint32(dk1)) * (dk1 >> 32)
 
-		dv2 := readU64(p, 8*2)
-		dk2 := dv2 ^ readU64(secret, 8*2)
-		accs[3] += dv2
-		accs[2] += (dk2 & 0xffffffff) * (dk2 >> 32)
+			accs[off] += ac0
+			accs[off+1] += ac1
+		}
+		{
+			const off = 2
+			dv0 := readU64(p, 8*off)
+			dk0 := dv0 ^ readU64(secret, 8*off)
+			ac1 := dv0
+			ac0 := uint64(uint32(dk0)) * (dk0 >> 32)
 
-		dv3 := readU64(p, 8*3)
-		dk3 := dv3 ^ readU64(secret, 8*3)
-		accs[2] += dv3
-		accs[3] += (dk3 & 0xffffffff) * (dk3 >> 32)
+			dv1 := readU64(p, 8*off+8)
+			dk1 := dv1 ^ readU64(secret, 8*off+8)
+			ac0 += dv1
+			ac1 += uint64(uint32(dk1)) * (dk1 >> 32)
 
-		dv4 := readU64(p, 8*4)
-		dk4 := dv4 ^ readU64(secret, 8*4)
-		accs[5] += dv4
-		accs[4] += (dk4 & 0xffffffff) * (dk4 >> 32)
+			accs[off] += ac0
+			accs[off+1] += ac1
+		}
+		{
+			const off = 4
+			dv0 := readU64(p, 8*off)
+			dk0 := dv0 ^ readU64(secret, 8*off)
+			ac1 := dv0
+			ac0 := uint64(uint32(dk0)) * (dk0 >> 32)
 
-		dv5 := readU64(p, 8*5)
-		dk5 := dv5 ^ readU64(secret, 8*5)
-		accs[4] += dv5
-		accs[5] += (dk5 & 0xffffffff) * (dk5 >> 32)
+			dv1 := readU64(p, 8*off+8)
+			dk1 := dv1 ^ readU64(secret, 8*off+8)
+			ac0 += dv1
+			ac1 += uint64(uint32(dk1)) * (dk1 >> 32)
 
-		dv6 := readU64(p, 8*6)
-		dk6 := dv6 ^ readU64(secret, 8*6)
-		accs[7] += dv6
-		accs[6] += (dk6 & 0xffffffff) * (dk6 >> 32)
+			accs[off] += ac0
+			accs[off+1] += ac1
+		}
+		{
+			const off = 6
+			dv0 := readU64(p, 8*off)
+			dk0 := dv0 ^ readU64(secret, 8*off)
+			ac1 := dv0
+			ac0 := uint64(uint32(dk0)) * (dk0 >> 32)
 
-		dv7 := readU64(p, 8*7)
-		dk7 := dv7 ^ readU64(secret, 8*7)
-		accs[6] += dv7
-		accs[7] += (dk7 & 0xffffffff) * (dk7 >> 32)
+			dv1 := readU64(p, 8*off+8)
+			dk1 := dv1 ^ readU64(secret, 8*off+8)
+			ac0 += dv1
+			ac1 += uint64(uint32(dk1)) * (dk1 >> 32)
+
+			accs[off] += ac0
+			accs[off+1] += ac1
+		}
 
 		p, secret = ptr(ui(p)+_stripe), ptr(ui(secret)+8)
 	}
@@ -281,45 +344,66 @@ func accumScalarSeed(accs *[8]u64, p, secret ptr, l u64) {
 
 		// accs
 		for i := 0; i < 16; i++ {
-			dv0 := readU64(p, 8*0)
-			dk0 := dv0 ^ readU64(k, 8*0)
-			accs[1] += dv0
-			accs[0] += (dk0 & 0xffffffff) * (dk0 >> 32)
+			{
+				const off = 0
+				dv0 := readU64(p, 8*off)
+				dk0 := dv0 ^ readU64(k, 8*off)
+				ac1 := dv0
+				ac0 := uint64(uint32(dk0)) * (dk0 >> 32)
 
-			dv1 := readU64(p, 8*1)
-			dk1 := dv1 ^ readU64(k, 8*1)
-			accs[0] += dv1
-			accs[1] += (dk1 & 0xffffffff) * (dk1 >> 32)
+				dv1 := readU64(p, 8*off+8)
+				dk1 := dv1 ^ readU64(k, 8*off+8)
+				ac0 += dv1
+				ac1 += uint64(uint32(dk1)) * (dk1 >> 32)
 
-			dv2 := readU64(p, 8*2)
-			dk2 := dv2 ^ readU64(k, 8*2)
-			accs[3] += dv2
-			accs[2] += (dk2 & 0xffffffff) * (dk2 >> 32)
+				accs[off] += ac0
+				accs[off+1] += ac1
+			}
+			{
+				const off = 2
+				dv0 := readU64(p, 8*off)
+				dk0 := dv0 ^ readU64(k, 8*off)
+				ac1 := dv0
+				ac0 := uint64(uint32(dk0)) * (dk0 >> 32)
 
-			dv3 := readU64(p, 8*3)
-			dk3 := dv3 ^ readU64(k, 8*3)
-			accs[2] += dv3
-			accs[3] += (dk3 & 0xffffffff) * (dk3 >> 32)
+				dv1 := readU64(p, 8*off+8)
+				dk1 := dv1 ^ readU64(k, 8*off+8)
+				ac0 += dv1
+				ac1 += uint64(uint32(dk1)) * (dk1 >> 32)
 
-			dv4 := readU64(p, 8*4)
-			dk4 := dv4 ^ readU64(k, 8*4)
-			accs[5] += dv4
-			accs[4] += (dk4 & 0xffffffff) * (dk4 >> 32)
+				accs[off] += ac0
+				accs[off+1] += ac1
+			}
+			{
+				const off = 4
+				dv0 := readU64(p, 8*off)
+				dk0 := dv0 ^ readU64(k, 8*off)
+				ac1 := dv0
+				ac0 := uint64(uint32(dk0)) * (dk0 >> 32)
 
-			dv5 := readU64(p, 8*5)
-			dk5 := dv5 ^ readU64(k, 8*5)
-			accs[4] += dv5
-			accs[5] += (dk5 & 0xffffffff) * (dk5 >> 32)
+				dv1 := readU64(p, 8*off+8)
+				dk1 := dv1 ^ readU64(k, 8*off+8)
+				ac0 += dv1
+				ac1 += uint64(uint32(dk1)) * (dk1 >> 32)
 
-			dv6 := readU64(p, 8*6)
-			dk6 := dv6 ^ readU64(k, 8*6)
-			accs[7] += dv6
-			accs[6] += (dk6 & 0xffffffff) * (dk6 >> 32)
+				accs[off] += ac0
+				accs[off+1] += ac1
+			}
+			{
+				const off = 6
+				dv0 := readU64(p, 8*off)
+				dk0 := dv0 ^ readU64(k, 8*off)
+				ac1 := dv0
+				ac0 := uint64(uint32(dk0)) * (dk0 >> 32)
 
-			dv7 := readU64(p, 8*7)
-			dk7 := dv7 ^ readU64(k, 8*7)
-			accs[6] += dv7
-			accs[7] += (dk7 & 0xffffffff) * (dk7 >> 32)
+				dv1 := readU64(p, 8*off+8)
+				dk1 := dv1 ^ readU64(k, 8*off+8)
+				ac0 += dv1
+				ac1 += uint64(uint32(dk1)) * (dk1 >> 32)
+
+				accs[off] += ac0
+				accs[off+1] += ac1
+			}
 
 			l -= _stripe
 			if l > 0 {
@@ -365,45 +449,66 @@ func accumScalarSeed(accs *[8]u64, p, secret ptr, l u64) {
 		t, k := (l-1)/_stripe, secret
 
 		for i := u64(0); i < t; i++ {
-			dv0 := readU64(p, 8*0)
-			dk0 := dv0 ^ readU64(k, 8*0)
-			accs[1] += dv0
-			accs[0] += (dk0 & 0xffffffff) * (dk0 >> 32)
+			{
+				const off = 0
+				dv0 := readU64(p, 8*off)
+				dk0 := dv0 ^ readU64(k, 8*off)
+				ac1 := dv0
+				ac0 := uint64(uint32(dk0)) * (dk0 >> 32)
 
-			dv1 := readU64(p, 8*1)
-			dk1 := dv1 ^ readU64(k, 8*1)
-			accs[0] += dv1
-			accs[1] += (dk1 & 0xffffffff) * (dk1 >> 32)
+				dv1 := readU64(p, 8*off+8)
+				dk1 := dv1 ^ readU64(k, 8*off+8)
+				ac0 += dv1
+				ac1 += uint64(uint32(dk1)) * (dk1 >> 32)
 
-			dv2 := readU64(p, 8*2)
-			dk2 := dv2 ^ readU64(k, 8*2)
-			accs[3] += dv2
-			accs[2] += (dk2 & 0xffffffff) * (dk2 >> 32)
+				accs[off] += ac0
+				accs[off+1] += ac1
+			}
+			{
+				const off = 2
+				dv0 := readU64(p, 8*off)
+				dk0 := dv0 ^ readU64(k, 8*off)
+				ac1 := dv0
+				ac0 := uint64(uint32(dk0)) * (dk0 >> 32)
 
-			dv3 := readU64(p, 8*3)
-			dk3 := dv3 ^ readU64(k, 8*3)
-			accs[2] += dv3
-			accs[3] += (dk3 & 0xffffffff) * (dk3 >> 32)
+				dv1 := readU64(p, 8*off+8)
+				dk1 := dv1 ^ readU64(k, 8*off+8)
+				ac0 += dv1
+				ac1 += uint64(uint32(dk1)) * (dk1 >> 32)
 
-			dv4 := readU64(p, 8*4)
-			dk4 := dv4 ^ readU64(k, 8*4)
-			accs[5] += dv4
-			accs[4] += (dk4 & 0xffffffff) * (dk4 >> 32)
+				accs[off] += ac0
+				accs[off+1] += ac1
+			}
+			{
+				const off = 4
+				dv0 := readU64(p, 8*off)
+				dk0 := dv0 ^ readU64(k, 8*off)
+				ac1 := dv0
+				ac0 := uint64(uint32(dk0)) * (dk0 >> 32)
 
-			dv5 := readU64(p, 8*5)
-			dk5 := dv5 ^ readU64(k, 8*5)
-			accs[4] += dv5
-			accs[5] += (dk5 & 0xffffffff) * (dk5 >> 32)
+				dv1 := readU64(p, 8*off+8)
+				dk1 := dv1 ^ readU64(k, 8*off+8)
+				ac0 += dv1
+				ac1 += uint64(uint32(dk1)) * (dk1 >> 32)
 
-			dv6 := readU64(p, 8*6)
-			dk6 := dv6 ^ readU64(k, 8*6)
-			accs[7] += dv6
-			accs[6] += (dk6 & 0xffffffff) * (dk6 >> 32)
+				accs[off] += ac0
+				accs[off+1] += ac1
+			}
+			{
+				const off = 6
+				dv0 := readU64(p, 8*off)
+				dk0 := dv0 ^ readU64(k, 8*off)
+				ac1 := dv0
+				ac0 := uint64(uint32(dk0)) * (dk0 >> 32)
 
-			dv7 := readU64(p, 8*7)
-			dk7 := dv7 ^ readU64(k, 8*7)
-			accs[6] += dv7
-			accs[7] += (dk7 & 0xffffffff) * (dk7 >> 32)
+				dv1 := readU64(p, 8*off+8)
+				dk1 := dv1 ^ readU64(k, 8*off+8)
+				ac0 += dv1
+				ac1 += uint64(uint32(dk1)) * (dk1 >> 32)
+
+				accs[off] += ac0
+				accs[off+1] += ac1
+			}
 
 			l -= _stripe
 			if l > 0 {
@@ -417,42 +522,42 @@ func accumScalarSeed(accs *[8]u64, p, secret ptr, l u64) {
 			dv0 := readU64(p, 8*0)
 			dk0 := dv0 ^ readU64(secret, 121)
 			accs[1] += dv0
-			accs[0] += (dk0 & 0xffffffff) * (dk0 >> 32)
+			accs[0] += uint64(uint32(dk0)) * (dk0 >> 32)
 
 			dv1 := readU64(p, 8*1)
 			dk1 := dv1 ^ readU64(secret, 129)
 			accs[0] += dv1
-			accs[1] += (dk1 & 0xffffffff) * (dk1 >> 32)
+			accs[1] += uint64(uint32(dk1)) * (dk1 >> 32)
 
 			dv2 := readU64(p, 8*2)
 			dk2 := dv2 ^ readU64(secret, 137)
 			accs[3] += dv2
-			accs[2] += (dk2 & 0xffffffff) * (dk2 >> 32)
+			accs[2] += uint64(uint32(dk2)) * (dk2 >> 32)
 
 			dv3 := readU64(p, 8*3)
 			dk3 := dv3 ^ readU64(secret, 145)
 			accs[2] += dv3
-			accs[3] += (dk3 & 0xffffffff) * (dk3 >> 32)
+			accs[3] += uint64(uint32(dk3)) * (dk3 >> 32)
 
 			dv4 := readU64(p, 8*4)
 			dk4 := dv4 ^ readU64(secret, 153)
 			accs[5] += dv4
-			accs[4] += (dk4 & 0xffffffff) * (dk4 >> 32)
+			accs[4] += uint64(uint32(dk4)) * (dk4 >> 32)
 
 			dv5 := readU64(p, 8*5)
 			dk5 := dv5 ^ readU64(secret, 161)
 			accs[4] += dv5
-			accs[5] += (dk5 & 0xffffffff) * (dk5 >> 32)
+			accs[5] += uint64(uint32(dk5)) * (dk5 >> 32)
 
 			dv6 := readU64(p, 8*6)
 			dk6 := dv6 ^ readU64(secret, 169)
 			accs[7] += dv6
-			accs[6] += (dk6 & 0xffffffff) * (dk6 >> 32)
+			accs[6] += uint64(uint32(dk6)) * (dk6 >> 32)
 
 			dv7 := readU64(p, 8*7)
 			dk7 := dv7 ^ readU64(secret, 177)
 			accs[6] += dv7
-			accs[7] += (dk7 & 0xffffffff) * (dk7 >> 32)
+			accs[7] += uint64(uint32(dk7)) * (dk7 >> 32)
 		}
 	}
 }
@@ -463,45 +568,66 @@ func accumBlockScalarSeed(accs *[8]u64, p, secret ptr) {
 	{
 		secret := secret
 		for i := 0; i < 16; i++ {
-			dv0 := readU64(p, 8*0)
-			dk0 := dv0 ^ readU64(secret, 8*0)
-			accs[1] += dv0
-			accs[0] += (dk0 & 0xffffffff) * (dk0 >> 32)
+			{
+				const off = 0
+				dv0 := readU64(p, 8*off)
+				dk0 := dv0 ^ readU64(secret, 8*off)
+				ac1 := dv0
+				ac0 := uint64(uint32(dk0)) * (dk0 >> 32)
 
-			dv1 := readU64(p, 8*1)
-			dk1 := dv1 ^ readU64(secret, 8*1)
-			accs[0] += dv1
-			accs[1] += (dk1 & 0xffffffff) * (dk1 >> 32)
+				dv1 := readU64(p, 8*off+8)
+				dk1 := dv1 ^ readU64(secret, 8*off+8)
+				ac0 += dv1
+				ac1 += uint64(uint32(dk1)) * (dk1 >> 32)
 
-			dv2 := readU64(p, 8*2)
-			dk2 := dv2 ^ readU64(secret, 8*2)
-			accs[3] += dv2
-			accs[2] += (dk2 & 0xffffffff) * (dk2 >> 32)
+				accs[off] += ac0
+				accs[off+1] += ac1
+			}
+			{
+				const off = 2
+				dv0 := readU64(p, 8*off)
+				dk0 := dv0 ^ readU64(secret, 8*off)
+				ac1 := dv0
+				ac0 := uint64(uint32(dk0)) * (dk0 >> 32)
 
-			dv3 := readU64(p, 8*3)
-			dk3 := dv3 ^ readU64(secret, 8*3)
-			accs[2] += dv3
-			accs[3] += (dk3 & 0xffffffff) * (dk3 >> 32)
+				dv1 := readU64(p, 8*off+8)
+				dk1 := dv1 ^ readU64(secret, 8*off+8)
+				ac0 += dv1
+				ac1 += uint64(uint32(dk1)) * (dk1 >> 32)
 
-			dv4 := readU64(p, 8*4)
-			dk4 := dv4 ^ readU64(secret, 8*4)
-			accs[5] += dv4
-			accs[4] += (dk4 & 0xffffffff) * (dk4 >> 32)
+				accs[off] += ac0
+				accs[off+1] += ac1
+			}
+			{
+				const off = 4
+				dv0 := readU64(p, 8*off)
+				dk0 := dv0 ^ readU64(secret, 8*off)
+				ac1 := dv0
+				ac0 := uint64(uint32(dk0)) * (dk0 >> 32)
 
-			dv5 := readU64(p, 8*5)
-			dk5 := dv5 ^ readU64(secret, 8*5)
-			accs[4] += dv5
-			accs[5] += (dk5 & 0xffffffff) * (dk5 >> 32)
+				dv1 := readU64(p, 8*off+8)
+				dk1 := dv1 ^ readU64(secret, 8*off+8)
+				ac0 += dv1
+				ac1 += uint64(uint32(dk1)) * (dk1 >> 32)
 
-			dv6 := readU64(p, 8*6)
-			dk6 := dv6 ^ readU64(secret, 8*6)
-			accs[7] += dv6
-			accs[6] += (dk6 & 0xffffffff) * (dk6 >> 32)
+				accs[off] += ac0
+				accs[off+1] += ac1
+			}
+			{
+				const off = 6
+				dv0 := readU64(p, 8*off)
+				dk0 := dv0 ^ readU64(secret, 8*off)
+				ac1 := dv0
+				ac0 := uint64(uint32(dk0)) * (dk0 >> 32)
 
-			dv7 := readU64(p, 8*7)
-			dk7 := dv7 ^ readU64(secret, 8*7)
-			accs[6] += dv7
-			accs[7] += (dk7 & 0xffffffff) * (dk7 >> 32)
+				dv1 := readU64(p, 8*off+8)
+				dk1 := dv1 ^ readU64(secret, 8*off+8)
+				ac0 += dv1
+				ac1 += uint64(uint32(dk1)) * (dk1 >> 32)
+
+				accs[off] += ac0
+				accs[off+1] += ac1
+			}
 
 			p, secret = ptr(ui(p)+_stripe), ptr(ui(secret)+8)
 		}

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,7 @@
 package xxh3
 
 import (
+	"encoding/binary"
 	"math/bits"
 	"unsafe"
 )
@@ -47,13 +48,12 @@ func readU16(p ptr, o ui) uint16 {
 
 func readU32(p ptr, o ui) uint32 {
 	b := (*[4]byte)(ptr(ui(p) + o))
-	return uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16 | uint32(b[3])<<24
+	return binary.LittleEndian.Uint32(b[:])
 }
 
 func readU64(p ptr, o ui) uint64 {
 	b := (*[8]byte)(ptr(ui(p) + o))
-	return uint64(b[0]) | uint64(b[1])<<8 | uint64(b[2])<<16 | uint64(b[3])<<24 |
-		uint64(b[4])<<32 | uint64(b[5])<<40 | uint64(b[6])<<48 | uint64(b[7])<<56
+	return binary.LittleEndian.Uint64(b[:])
 }
 
 func writeU64(p ptr, o ui, v u64) {


### PR DESCRIPTION
* Only accumulate once to memory.
* Use cast instead of AND to truncate.
* Use binary.LittleEndian - observed some cases where it didn't use single instruction to load while testing.
* Make code a bit easier to copy+paste. Tried a function, but it wouldn't inline properly.

```
benchmark                                   old ns/op     new ns/op     delta
BenchmarkHasher64/16/go/plain-32            10.8          10.8          +0.18%
BenchmarkHasher64/16/go/seed-32             11.5          11.5          -0.52%
BenchmarkHasher64/64/go/plain-32            13.2          13.5          +1.89%
BenchmarkHasher64/64/go/seed-32             14.5          14.5          -0.48%
BenchmarkHasher64/256/go/plain-32           42.0          38.4          -8.48%
BenchmarkHasher64/256/go/seed-32            55.3          53.3          -3.74%
BenchmarkHasher64/1024/go/plain-32          116           96.8          -16.17%
BenchmarkHasher64/1024/go/seed-32           131           113           -13.91%
BenchmarkHasher64/4096/go/plain-32          411           320           -22.10%
BenchmarkHasher64/4096/go/seed-32           408           324           -20.58%
BenchmarkHasher64/16384/go/plain-32         1575          1220          -22.54%
BenchmarkHasher64/16384/go/seed-32          1567          1245          -20.55%
BenchmarkHasher64/65536/go/plain-32         6215          4825          -22.37%
BenchmarkHasher64/65536/go/seed-32          6170          4900          -20.58%
BenchmarkHasher64/262144/go/plain-32        24618         19150         -22.21%
BenchmarkHasher64/262144/go/seed-32         24556         19472         -20.70%
BenchmarkHasher64/1048576/go/plain-32       100340        76903         -23.36%
BenchmarkHasher64/1048576/go/seed-32        98686         78452         -20.50%
BenchmarkHasher64/4194304/go/plain-32       397258        310424        -21.86%
BenchmarkHasher64/4194304/go/seed-32        393518        316373        -19.60%
BenchmarkHasher64/16777216/go/plain-32      1759263       1392247       -20.86%
BenchmarkHasher64/16777216/go/seed-32       1795954       1420991       -20.88%
BenchmarkHasher64/67108864/go/plain-32      8285671       5713840       -31.04%
BenchmarkHasher64/67108864/go/seed-32       8034171       5773070       -28.14%
BenchmarkHasher64/268435456/go/plain-32     33112283      22882546      -30.89%
BenchmarkHasher64/268435456/go/seed-32      33193939      23083580      -30.46%

benchmark                                   old MB/s     new MB/s     speedup
BenchmarkHasher64/16/go/plain-32            1479.39      1475.91      1.00x
BenchmarkHasher64/16/go/seed-32             1386.08      1393.51      1.01x
BenchmarkHasher64/64/go/plain-32            4836.06      4748.53      0.98x
BenchmarkHasher64/64/go/seed-32             4401.57      4422.27      1.00x
BenchmarkHasher64/256/go/plain-32           6100.65      6667.03      1.09x
BenchmarkHasher64/256/go/seed-32            4625.77      4805.92      1.04x
BenchmarkHasher64/1024/go/plain-32          8866.30      10576.22     1.19x
BenchmarkHasher64/1024/go/seed-32           7829.90      9094.16      1.16x
BenchmarkHasher64/4096/go/plain-32          9967.92      12796.39     1.28x
BenchmarkHasher64/4096/go/seed-32           10035.09     12632.76     1.26x
BenchmarkHasher64/16384/go/plain-32         10399.26     13433.97     1.29x
BenchmarkHasher64/16384/go/seed-32          10455.46     13160.54     1.26x
BenchmarkHasher64/65536/go/plain-32         10544.91     13583.15     1.29x
BenchmarkHasher64/65536/go/seed-32          10621.16     13373.47     1.26x
BenchmarkHasher64/262144/go/plain-32        10648.57     13688.70     1.29x
BenchmarkHasher64/262144/go/seed-32         10675.56     13462.41     1.26x
BenchmarkHasher64/1048576/go/plain-32       10450.25     13634.96     1.30x
BenchmarkHasher64/1048576/go/seed-32        10625.35     13365.79     1.26x
BenchmarkHasher64/4194304/go/plain-32       10558.14     13511.52     1.28x
BenchmarkHasher64/4194304/go/seed-32        10658.47     13257.47     1.24x
BenchmarkHasher64/16777216/go/plain-32      9536.50      12050.46     1.26x
BenchmarkHasher64/16777216/go/seed-32       9341.67      11806.70     1.26x
BenchmarkHasher64/67108864/go/plain-32      8099.39      11744.97     1.45x
BenchmarkHasher64/67108864/go/seed-32       8352.93      11624.47     1.39x
BenchmarkHasher64/268435456/go/plain-32     8106.82      11731.01     1.45x
BenchmarkHasher64/268435456/go/seed-32      8086.88      11628.85     1.44x
```